### PR TITLE
fixed import path for /runtime for node esm

### DIFF
--- a/.changeset/stale-trainers-enjoy.md
+++ b/.changeset/stale-trainers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'scripts': patch
+---
+
+fixed /runtime resolution for node esm

--- a/packages/_scripts/buildNode.js
+++ b/packages/_scripts/buildNode.js
@@ -108,8 +108,8 @@ export async function buildPackage({ packageJSONPath, source, outDir, plugin, on
 				import: `./build/${dirname}/index.js`,
 			}
 			package_json.exports['./' + dirname + "/*"] = {
-				types: `./build/${dirname}/*`,
-				import: `./build/${dirname}/*`,
+				types: `./build/${dirname}/*.d.ts`,
+				import: `./build/${dirname}/*.js`,
 			}
 			package_json.typesVersions['*'][dirname] = [`./build/${dirname}/index.d.ts`]
 		}


### PR DESCRIPTION
build was breaking since it was not able to resolve some of the /runtime deps

Fixes #TICKET

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
